### PR TITLE
Add OWASP zap scan image

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ list of vendored base images
 | ghcr.io/geonet/base-images/ubi8-minimal        | Red Hat Universal Base Image 8 minimal                                         |
 | ghcr.io/geonet/base-images/centos              | Centos 7 and stream variants available as tags eg :centos7 :stream8            |
 | ghcr.io/geonet/base-images/chart-centos7       | Centos 7 base image updated to add extract packages needed for the chart app   |
-| ghcr.io/geonet/base-images/curl                                               | A minimal image only containing curl                                                                               |
+| ghcr.io/geonet/base-images/curl                | A minimal image only containing curl                                           |
+| ghcr.io/geonet/base-images/owasp/zap2docker-stable | An image to run OWASP's Zed Attack Proxy security web scanner              |
 
 
 for tags, check [config.yaml](./config.yaml).

--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,8 @@ sync:
     destination: ghcr.io/geonet/base-images/centos:stream8
   - source: cgr.dev/chainguard/curl:8.1.2@sha256:73992422b3e634c520483bb0aeda22c405d4701ccf5c2294c71d7f67373301cb
     destination: ghcr.io/geonet/base-images/curl:8.1.2
+  - source: docker.io/owasp/zap2docker-stable:2.11.1@sha256:47ba18f36de06f253e655d26ad78945c6dc24404e58f1c0758293a583bb99ce5
+    destination: ghcr.io/geonet/base-images/owasp/zap2docker-stable:2.11.1
 build:
   # NOTES
   # - uses dirname of source as context for build


### PR DESCRIPTION
Reference: https://github.com/GeoNet/devx/issues/136

Note: no idea what I'm doing.

I want to add [this OWASP docker image](https://hub.docker.com/layers/owasp/zap2docker-stable/2.11.1/images/sha256-47911f0e0fc82ab2e660bc2af54c84bae0f4b7b1f89f25b0a7d6e5baa163594a) we use for the [weekly security webscan](https://github.com/GeoNet/DevTools/blob/069444594014ca8a9fc1e4dc48bf0bb2234f236b/cmd/webscan/Dockerfile#L19) in `DevTools` (used to be in `devx`, hence the devx ticket).

Let me know if there's anything else I need to do.

