### PR TITLE
feat: add workflow to verify images are public

### DIFF
--- a/.github/workflows/images-are-public.yml
+++ b/.github/workflows/images-are-public.yml
@@ -1,0 +1,16 @@
+name: images are public
+on:
+  push:
+    branches:
+      - main
+jobs:
+  images-are-public:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
+      - name: check images are public
+        run: |
+          # NOTE: important to not use auth
+          jq -r -c '.sync as $sync | .build as $build | {"include":[{"destination": $sync[].destination}, {"destination": $build[].destination}]} | .include[].destination' <<< "$(yq e . -o json config.yaml)" | xargs -n 1 -I{} crane digest {}


### PR DESCRIPTION
runs on main for after image have been built and synced