### PR TITLE
fix: remove entrypoints from shell-less images

### DIFF
--- a/images/alpine-gdal/image.yaml
+++ b/images/alpine-gdal/image.yaml
@@ -8,9 +8,6 @@ contents:
     - tzdata
     - gdal
 
-entrypoint:
-  command: /bin/sh -c
-
 archs:
   - x86_64
   - aarch64

--- a/images/alpine-xslt/image.yaml
+++ b/images/alpine-xslt/image.yaml
@@ -7,9 +7,6 @@ contents:
     - tzdata
     - libxslt
 
-entrypoint:
-  command: /bin/sh -c
-
 archs:
   - x86_64
   - aarch64

--- a/images/git/image.yaml
+++ b/images/git/image.yaml
@@ -7,9 +7,6 @@ contents:
     - tzdata
     - git
 
-entrypoint:
-  command: /bin/sh -c
-
 archs:
-- x86_64
-- aarch64
+  - x86_64
+  - aarch64


### PR DESCRIPTION
removes shell entrypoint for images which don't ship shells