### PR TITLE
feat: add git image with ssh baked in

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ sync:
     destination: ghcr.io/geonet/base-images/siderolabs-conform:v0.1.0-alpha.27
   - source: quay.io/centos/centos:7@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e
     destination: ghcr.io/geonet/base-images/centos:centos7
-  - source: quay.io/centos/centos@sha256:59460e4360f0657a24ce56339b117f14ac236dd51e1cf33f30ed5725ba1b4429 # stream8 for 2023-07-12
+  - source: quay.io/centos/centos@sha256:35893b01e9bf8ac6357015d44b8641160297fa95019643b29db5fcc8e98ad86f # stream8 for 2023-08-25
     destination: ghcr.io/geonet/base-images/centos:stream8
   - source: cgr.dev/chainguard/curl:8.1.2@sha256:73992422b3e634c520483bb0aeda22c405d4701ccf5c2294c71d7f67373301cb
     destination: ghcr.io/geonet/base-images/curl:8.1.2
@@ -51,7 +51,7 @@ sync:
     destination: ghcr.io/geonet/base-images/owasp/zap2docker-stable:2.11.1
   - source: quay.io/fedora/fedora@sha256:1972716109b1c906120061063bd4cb50a46c2138d95002ccb90126928d98e013 # 38 2023-08-07
     destination: ghcr.io/geonet/base-images/fedora:38
-  - source: quay.io/fedora/fedora-coreos@sha256:024db61a886b3a6e008683af92a25cf084635b3c20cc3d3dee5931045d2f6dab # 38 stable 2023-08-08
+  - source: quay.io/fedora/fedora-coreos@sha256:1100ec4cc0ec47e9846750137b43dedf4f20d9b56bafb99f5866ceff152f88d1 # 38 stable 2023-08-25
     destination: ghcr.io/geonet/base-images/fedora-coreos:stable
 build:
   # NOTES

--- a/images/git-ssh/image.yaml
+++ b/images/git-ssh/image.yaml
@@ -1,0 +1,13 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/v3.17/main
+  packages:
+    - alpine-baselayout-data
+    - ca-certificates-bundle
+    - tzdata
+    - git
+    - ssh
+
+archs:
+  - x86_64
+  - aarch64


### PR DESCRIPTION
This is image is needed for use when git is being used to interact with a repo via ssh. It's aimed at the field containers which do auditing and backups into github.