### PR TITLE
chore: use standard golang images

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,9 +27,9 @@ sync:
     destination: ghcr.io/geonet/base-images/python:3.11.4-alpine3.18
   - source: docker.io/library/golang:1.16-alpine3.15@sha256:5616dca835fa90ef13a843824ba58394dad356b7d56198fb7c93cbe76d7d67fe
     destination: ghcr.io/geonet/base-images/go:1.16 # until ko has been fully adopted and Go 1.16 => 1.20/1.21
-  - source: cgr.dev/chainguard/go:latest@sha256:829594acdbc0f50ea5cae9ae208224999c21d1ee3dfe8003b177814056a827f1
+  - source: docker.io/golang:1.20.7-alpine3.18@sha256:03278bc16e1a5b4fb6cdd3462108c060aa1e9c2353ce4d15d744b3c40168677d
     destination: ghcr.io/geonet/base-images/go:1.20 # until ko has been fully adopted
-  - source: cgr.dev/chainguard/go:latest@sha256:5b38eade1728ebe11473c832176e080e4baae756ef1f324e6712075b26bf111c # may need to swap out for docker.io/golang:1.21.0-alpine3.18 if some Dockerfiles aren't able to be slightly rewritten due to no package manager etc
+  - source: docker.io/golang:1.21.0-alpine3.18@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f
     destination: ghcr.io/geonet/base-images/go:1.21 # until ko has been fully adopted
   - source: cgr.dev/chainguard/static:latest@sha256:da9822ad6f973e40e24e75133b08ae874900766873ecd03e58f7f630ccea898c
     destination: ghcr.io/geonet/base-images/static:latest


### PR DESCRIPTION
attempt to resolve requirement for apk in some image builds

issue: https://github.com/GeoNet/4D-Ashfall/actions/runs/5898532654/job/15999708341?pr=35#step:19:197

cc @CallumNZ 

although, the Chainguard images are preferred since they can be reproducibly built, they don't ship with package managers