### PR TITLE
feat: add shellcheck to sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ list of vendored base images
 | ghcr.io/geonet/base-images/fedora                  | fedora for build tasks                                                         |
 | ghcr.io/geonet/base-images/fedora-coreos           | fedora coreos for edge devices                                                 |
 | ghcr.io/geonet/base-images/alpine-iputils          | includes tools like ping                                                       |
+| ghcr.io/geonet/base-images/shellcheck              | shellcheck bash scripts                                                                               |
 
 
 for tags, check [config.yaml](./config.yaml).

--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,8 @@ sync:
     destination: ghcr.io/geonet/base-images/fedora:38
   - source: quay.io/fedora/fedora-coreos@sha256:0696dd182d2929d3697c0caa191489b88a47d3e1b3921b361961b2af5e1f7988 # 38 stable 2023-09-07
     destination: ghcr.io/geonet/base-images/fedora-coreos:stable
+  - source: docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7
+    destination: ghcr.io/geonet/base-images/shellcheck:v0.9.0
 build:
   # NOTES
   # - uses dirname of source as context for build


### PR DESCRIPTION
adds a copy of the shellcheck container

depends on: https://github.com/GeoNet/Actions/pull/174