### PR TITLE
feat: sync datadog agent to ECR

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -46,6 +46,27 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+      - id: determine-uses-ecr
+        env:
+          DESTINATION: ${{ fromJSON(toJSON(matrix)).destination }}
+        run: |
+          if echo "$DESTINATION" | grep -q -E '[0-9]{12}.dkr.ecr.ap-southeast-2.amazonaws.com/.*'; then
+            echo "ecr="$(echo "$DESTINATION" | cut -d'/' -f1)"" >> $GITHUB_OUTPUT
+          fi
+      - name: Configure AWS Credentials
+        if: ${{ steps.determine-uses-ecr.outputs.ecr != '' }}
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v2.0.0
+        with:
+          aws-region: ap-southeast-2
+          role-to-assume: arn:aws:iam::862640294325:role/github-actions-geonet-ecr-push
+          role-duration-seconds: 3600
+          role-session-name: github-actions-GeoNet--base-images
+      - name: login to ECR
+        if: ${{ steps.determine-uses-ecr.outputs.ecr != '' }}
+        env:
+          ECR: ${{ steps.determine-uses-ecr.outputs.ecr }}
+        run: |
+          aws ecr get-login-password --region ap-southeast-2 | crane auth login "$ECR" -u AWS --password-stdin
       - name: get-digests
         if: ${{ fromJSON(toJSON(matrix)).always != true }}
         id: get-digests

--- a/README.md
+++ b/README.md
@@ -41,40 +41,41 @@ The repo is mostly concerned with base images or images used in build processes.
 
 list of vendored base images
 
-| Image                                              | Description                                                                    |
-|----------------------------------------------------|--------------------------------------------------------------------------------|
-| ghcr.io/geonet/base-images/alpine                  | standard Alpine base image                                                     |
-| ghcr.io/geonet/base-images/datadog/agent           | datadog agent                                                                  |
-| ghcr.io/geonet/base-images/debian                  | standard Debian slim image                                                     |
-| ghcr.io/geonet/base-images/git                     | Alpine with git installed                                                      |
-| ghcr.io/geonet/base-images/git-ssh                 | Alpine with git and ssh installed                                              |
-| ghcr.io/geonet/base-images/go                      | a minimal image for building Go applications                                   |
-| ghcr.io/geonet/base-images/hadolint/hadolint       | a Dockerfile linter                                                            |
-| ghcr.io/geonet/base-images/hashicorp/terraform     | Terraform image                                                                |
-| ghcr.io/geonet/base-images/mkdocs_plus             | a custom build image for docs                                                  |
-| ghcr.io/geonet/base-images/nginx                   | minimal nginx image                                                            |
-| ghcr.io/geonet/base-images/node                    | Alpine based node image                                                        |
-| ghcr.io/geonet/base-images/python                  | Alpine and Debian base Python images                                           |
-| ghcr.io/geonet/base-images/siderolabs-conform      | conform policy for pull request commits                                        |
-| ghcr.io/geonet/base-images/static                  | scratch with timezone and ca-certificate data pre-installed. Great for Go apps |
-| ghcr.io/geonet/base-images/texlive                 | a latex image                                                                  |
-| ghcr.io/geonet/base-images/ubi8                    | Red Hat Universal Base Image 8                                                 |
-| ghcr.io/geonet/base-images/ubi8-minimal            | Red Hat Universal Base Image 8 minimal                                         |
-| ghcr.io/geonet/base-images/centos                  | Centos 7 and stream variants available as tags eg :centos7 :stream8            |
-| ghcr.io/geonet/base-images/chart-centos7           | Centos 7 base image updated to add extract packages needed for the chart app   |
-| ghcr.io/geonet/base-images/curl                    | A minimal image only containing curl                                           |
-| ghcr.io/geonet/base-images/owasp/zap2docker-stable | An image to run OWASP's Zed Attack Proxy security web scanner                  |
-| ghcr.io/geonet/base-images/alpine-xslt             | Alpine with libxslt for XML parsing                                            |
-| ghcr.io/geonet/base-images/alpine-gdal             | Alpine with gdal for raster and vector geospatial data formats                 |
-| ghcr.io/geonet/base-images/fedora                  | fedora for build tasks                                                         |
-| ghcr.io/geonet/base-images/fedora-coreos           | fedora coreos for edge devices                                                 |
-| ghcr.io/geonet/base-images/alpine-iputils          | includes tools like ping                                                       |
-| ghcr.io/geonet/base-images/shellcheck              | shellcheck bash scripts                                                        |
-| ghcr.io/geonet/base-images/rpmbuild-centos7        | image for building RPMs with, based on CentOS 7                                |
-| ghcr.io/geonet/base-images/rpmbuild-centos-stream8 | image for building RPMs with, based on CentOS Stream 8                         |
-| ghcr.io/geonet/base-images/rpmbuild-centos-stream9 | image for building RPMs with, based on CentOS Stream 9                         |
-| ghcr.io/geonet/base-images/yq                      | yq for GitHub actions                                                          |
-| ghcr.io/geonet/base-images/binfmt                  | Cross-platform emulator collection distributed with Docker images              |
+| Image                                                           | Description                                                                    |
+|-----------------------------------------------------------------|--------------------------------------------------------------------------------|
+| ghcr.io/geonet/base-images/alpine                               | standard Alpine base image                                                     |
+| ghcr.io/geonet/base-images/datadog/agent                        | datadog agent                                                                  |
+| ghcr.io/geonet/base-images/debian                               | standard Debian slim image                                                     |
+| ghcr.io/geonet/base-images/git                                  | Alpine with git installed                                                      |
+| ghcr.io/geonet/base-images/git-ssh                              | Alpine with git and ssh installed                                              |
+| ghcr.io/geonet/base-images/go                                   | a minimal image for building Go applications                                   |
+| ghcr.io/geonet/base-images/hadolint/hadolint                    | a Dockerfile linter                                                            |
+| ghcr.io/geonet/base-images/hashicorp/terraform                  | Terraform image                                                                |
+| ghcr.io/geonet/base-images/mkdocs_plus                          | a custom build image for docs                                                  |
+| ghcr.io/geonet/base-images/nginx                                | minimal nginx image                                                            |
+| ghcr.io/geonet/base-images/node                                 | Alpine based node image                                                        |
+| ghcr.io/geonet/base-images/python                               | Alpine and Debian base Python images                                           |
+| ghcr.io/geonet/base-images/siderolabs-conform                   | conform policy for pull request commits                                        |
+| ghcr.io/geonet/base-images/static                               | scratch with timezone and ca-certificate data pre-installed. Great for Go apps |
+| ghcr.io/geonet/base-images/texlive                              | a latex image                                                                  |
+| ghcr.io/geonet/base-images/ubi8                                 | Red Hat Universal Base Image 8                                                 |
+| ghcr.io/geonet/base-images/ubi8-minimal                         | Red Hat Universal Base Image 8 minimal                                         |
+| ghcr.io/geonet/base-images/centos                               | Centos 7 and stream variants available as tags eg :centos7 :stream8            |
+| ghcr.io/geonet/base-images/chart-centos7                        | Centos 7 base image updated to add extract packages needed for the chart app   |
+| ghcr.io/geonet/base-images/curl                                 | A minimal image only containing curl                                           |
+| ghcr.io/geonet/base-images/owasp/zap2docker-stable              | An image to run OWASP's Zed Attack Proxy security web scanner                  |
+| ghcr.io/geonet/base-images/alpine-xslt                          | Alpine with libxslt for XML parsing                                            |
+| ghcr.io/geonet/base-images/alpine-gdal                          | Alpine with gdal for raster and vector geospatial data formats                 |
+| ghcr.io/geonet/base-images/fedora                               | fedora for build tasks                                                         |
+| ghcr.io/geonet/base-images/fedora-coreos                        | fedora coreos for edge devices                                                 |
+| ghcr.io/geonet/base-images/alpine-iputils                       | includes tools like ping                                                       |
+| ghcr.io/geonet/base-images/shellcheck                           | shellcheck bash scripts                                                        |
+| ghcr.io/geonet/base-images/rpmbuild-centos7                     | image for building RPMs with, based on CentOS 7                                |
+| ghcr.io/geonet/base-images/rpmbuild-centos-stream8              | image for building RPMs with, based on CentOS Stream 8                         |
+| ghcr.io/geonet/base-images/rpmbuild-centos-stream9              | image for building RPMs with, based on CentOS Stream 9                         |
+| ghcr.io/geonet/base-images/yq                                   | yq for GitHub actions                                                          |
+| ghcr.io/geonet/base-images/binfmt                               | Cross-platform emulator collection distributed with Docker images              |
+| 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com/datadog-agent | datadog agent for use in ECS                                                   |
 
 for tags, check [config.yaml](./config.yaml).
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,8 +18,10 @@ sync:
     destination: ghcr.io/geonet/base-images/ubi8:8.8
   - source: docker.io/redhat/ubi8-minimal:8.8@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
     destination: ghcr.io/geonet/base-images/ubi8-minimal:8.8
-  - source: docker.io/datadog/agent:7@sha256:b9e11fd44fec2dc6f42d7d8eeafb29dc16bc185af37c395b9c3864b1402134d0
-    destination: ghcr.io/geonet/base-images/datadog/agent:7
+  - source: docker.io/datadog/agent:7.47.1@sha256:364b90eb9da1925a4b8a1dca501a9a8e8cd5e8455733a16857284c49d4bf8467
+    destination: ghcr.io/geonet/base-images/datadog/agent:7.47.1
+  - source: docker.io/datadog/agent:7.47.1@sha256:364b90eb9da1925a4b8a1dca501a9a8e8cd5e8455733a16857284c49d4bf8467
+    destination: 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com/datadog-agent:7.47.1
   - source: docker.io/library/debian:bookworm-slim@sha256:d8f9d38c21495b04d1cca99805fbb383856e19794265684019bf193c3b7d67f9
     destination: ghcr.io/geonet/base-images/debian:bookworm-slim
   - source: docker.io/hadolint/hadolint:v2.12.0-alpine@sha256:3c206a451cec6d486367e758645269fd7d696c5ccb6ff59d8b03b0e45268a199
@@ -64,8 +66,9 @@ sync:
     destination: ghcr.io/geonet/base-images/mkdocs_plus:2023-06-14
   - source: ghcr.io/siderolabs/conform:v0.1.0-alpha.27@sha256:60e5c3cac83104077aff44a86518972f92cffb48d06c06486fb1f2711d4eb559
     destination: ghcr.io/geonet/base-images/siderolabs-conform:v0.1.0-alpha.27
-  - source: quay.io/fedora/fedora@sha256:1972716109b1c906120061063bd4cb50a46c2138d95002ccb90126928d98e013
+  - source: quay.io/fedora/fedora@sha256:d643707ffb780448c26dd5164edba3291aa39dbd790d06fbf779511bbe32cba9 # 1972716109b1c906120061063bd4cb50a46c2138d95002ccb90126928d98e013 for 2023-10-10
     destination: ghcr.io/geonet/base-images/fedora:38
+    auto-update-mutable-tag-digest: true
   - source: quay.io/fedora/fedora-coreos:stable@sha256:dd761341e1a97542467d8ec43e2b096271ca5a409d420d3e79ddba07940ea1b0 # stable for 2023-10-05
     destination: ghcr.io/geonet/base-images/fedora-coreos:stable
     auto-update-mutable-tag-digest: true
@@ -75,7 +78,7 @@ sync:
   - source: quay.io/centos/centos:stream8@sha256:86ba0bf60249e6daee350459e014213742c88341e6e7284695dcf1dfe2c58873 # stream8 for 2023-10-04
     destination: ghcr.io/geonet/base-images/centos:stream8
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:stream9@sha256:2e2a9f4f7171ccda195f3935192f1150155daab4da305f8c273e9fe6134fe7fa # stream9 for 2023-10-03
+  - source: quay.io/centos/centos:stream9@sha256:c5deeca5c7d68819832207602f7eb188f69b4c1e779bfc5debf6b3dedfe258ed # stream9 for 2023-10-10
     destination: ghcr.io/geonet/base-images/centos:stream9
     auto-update-mutable-tag-digest: true
   - source: cgr.dev/chainguard/curl:8.1.2@sha256:73992422b3e634c520483bb0aeda22c405d4701ccf5c2294c71d7f67373301cb


### PR DESCRIPTION
vendors the datadog agent image to an ECR

adds AWS and ECR auth to sync function (not build).

Requires an ECR for _datadog-agent_ to exist.

depends on: https://github.com/GeoNet/terraform-aws/pull/938
fixes: https://github.com/GeoNet/tickets/issues/10235