### PR TITLE
Revert "chore: use geonetci user to make updates to images"

### DIFF
--- a/.github/workflows/update-image-digests.yml
+++ b/.github/workflows/update-image-digests.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: GeoNet/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # main
       - name: configure system
         run: |
-          git config user.name 'geonetci'
-          git config user.email 'geonetci@gns.cri.nz'
-          gh auth login --with-token < <(echo ${{ secrets.GH_CI_USER_TOKEN }})
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          gh auth login --with-token < <(echo ${{ secrets.GITHUB_TOKEN }})
           gh auth status
       - name: update select images
         run: ./hack/update-sync-image-digests.sh
@@ -46,7 +46,6 @@ jobs:
           TIMESTAMP: ${{ steps.branch.outputs.timestamp }}
           NEW_BRANCH: ${{ steps.branch.outputs.new-branch-name }}
           HAS_EXISTING: ${{ steps.branch.outputs.has-existing }}
-          GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
           git add ./config.yaml
           git branch "${NEW_BRANCH}"

--- a/config.yaml
+++ b/config.yaml
@@ -75,10 +75,10 @@ sync:
   - source: quay.io/centos/centos:7@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e # 7 for 2023-09-21
     destination: ghcr.io/geonet/base-images/centos:centos7
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:stream8@sha256:e37216aac8ca51998d041a3c519cb3dee6e94573765716e7ddd5134445fed4da # stream8 for 2023-10-11
+  - source: quay.io/centos/centos:stream8@sha256:f24005786295703fc65e5cd74ab90497a05479fac780790a43eab5729f9e098f # stream8 for 2023-10-18
     destination: ghcr.io/geonet/base-images/centos:stream8
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:stream9@sha256:743cf31b5c29c227aa1371eddd9f9313b2a0487f39ccfc03ec5c89a692c4a0c7 # stream9 for 2023-10-11
+  - source: quay.io/centos/centos:stream9@sha256:aeca8aee6df1e62c25f306396dc6631520dc350fe90d48cf30f45272ffeb2c61 # stream9 for 2023-10-18
     destination: ghcr.io/geonet/base-images/centos:stream9
     auto-update-mutable-tag-digest: true
   - source: cgr.dev/chainguard/curl:8.1.2@sha256:73992422b3e634c520483bb0aeda22c405d4701ccf5c2294c71d7f67373301cb


### PR DESCRIPTION
Reverts GeoNet/base-images#124

getting the following error message

> error validating token: missing required scope 'read:org'