### PR TITLE
fix: Downgrade GeoNet/alpine-gdal to Alpine 3.15

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -111,7 +111,7 @@ build:
   - source: ./images/alpine-xslt/image.yaml
     destination: ghcr.io/geonet/base-images/alpine-xslt:3.18
   - source: ./images/alpine-gdal/image.yaml
-    destination: ghcr.io/geonet/base-images/alpine-gdal:3.18
+    destination: ghcr.io/geonet/base-images/alpine-gdal:3.15
   - source: ./images/texlive/image.yaml
     destination: ghcr.io/geonet/base-images/texlive:latest
   - source: ./images/chart-centos7/Dockerfile

--- a/images/alpine-gdal/image.yaml
+++ b/images/alpine-gdal/image.yaml
@@ -1,9 +1,8 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
-    - https://dl-cdn.alpinelinux.org/alpine/v3.18/community
+    - https://dl-cdn.alpinelinux.org/alpine/v3.15/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.15/community
   packages:
-    - alpine-baselayout-data
     - ca-certificates-bundle
     - tzdata
     - gdal


### PR DESCRIPTION
I assume currently the only project using this container is Shakinglayer, which's code only works with Gdal 3.4.

And, the Shakinglayer's base build image is Go1.16, which gives Gdal 3.4, and the existing GeoNet/alpine-gdal uses Alpine 3.18, give Gdal 3.6. This causes the runtime error.

Unfortunately we need to downgrade to Alpine 3.15 to get Gdal 3.4 so builder and runner can be in sync.
Also the code only works when it's Gdal 3.4.

Built instances deployed in dev environment works well.
