### PR TITLE
chore: update centos stream hashes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,10 +75,10 @@ sync:
   - source: quay.io/centos/centos:7@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e # 7 for 2023-09-21
     destination: ghcr.io/geonet/base-images/centos:centos7
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:stream8@sha256:f24005786295703fc65e5cd74ab90497a05479fac780790a43eab5729f9e098f # stream8 for 2023-10-19
+  - source: quay.io/centos/centos:stream8@sha256:b1f6889548eda34b2ddc8c2f50a49bf9924164814308e41e90a07e3b30e0db7f # stream8 for 2023-10-25
     destination: ghcr.io/geonet/base-images/centos:stream8
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:stream9@sha256:aeca8aee6df1e62c25f306396dc6631520dc350fe90d48cf30f45272ffeb2c61 # stream9 for 2023-10-19
+  - source: quay.io/centos/centos:stream9@sha256:c68569fe2075fb6372012174a7350a2bc0e90ce41a028963afc3193820061590 # stream9 for 2023-10-25
     destination: ghcr.io/geonet/base-images/centos:stream9
     auto-update-mutable-tag-digest: true
   - source: cgr.dev/chainguard/curl:8.1.2@sha256:73992422b3e634c520483bb0aeda22c405d4701ccf5c2294c71d7f67373301cb


### PR DESCRIPTION
The scheduled update job failed due to the hashes not existing.

Looking at the history, I can see these were changed https://quay.io/repository/centos/centos?tab=history