### PR TITLE
fix: force arm64 on fedora

### DIFF
--- a/images/rpmbuild-fedora/Dockerfile
+++ b/images/rpmbuild-fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/geonet/base-images/fedora:38
+FROM --platform=linux/arm64 ghcr.io/geonet/base-images/fedora:38
 # Installing tools needed for rpmbuild
 RUN dnf update -y && \
     dnf install -y \


### PR DESCRIPTION
primarily for containerised compute at edge builds
aiming to fix
![image of amd64 build and unknown build image](https://github.com/GeoNet/base-images/assets/3606406/bb34b496-e1f8-45ff-8b33-58681b82cf4e)
