### PR TITLE
fix: use aarch64 image on arm64 build

### DIFF
--- a/images/rpmbuild-fedora/Dockerfile
+++ b/images/rpmbuild-fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/geonet/base-images/fedora:38
+FROM ghcr.io/geonet/base-images/fedora:38-aarch64
 # Installing tools needed for rpmbuild
 RUN dnf update -y && \
     dnf install -y \


### PR DESCRIPTION
I failed to understand the builds are on separate tags for fedora

this change makes the rpmbuild image use arm64 base