### PR TITLE
fix: centos upstream image tag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -75,7 +75,7 @@ sync:
   - source: quay.io/fedora/fedora-coreos:stable@sha256:edf82907b4dad33a8d94f9bbc883b303d62014df110c1a7df7af5c61514458e1 # stable for 2023-11-24
     destination: ghcr.io/geonet/base-images/fedora-coreos:stable
     auto-update-mutable-tag-digest: true
-  - source: quay.io/centos/centos:7@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e # 7 for 2023-09-21
+  - source: quay.io/centos/centos:centos7@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e # 7 for 2023-09-21
     destination: ghcr.io/geonet/base-images/centos:centos7
     auto-update-mutable-tag-digest: true
   - source: quay.io/centos/centos:stream8@sha256:5917fa6bdbced823c488264ba03f1cfab852c15b5e47714fc8c9a074adc7cfdd # stream8 for 2023-11-29


### PR DESCRIPTION
busywork as centos:7 tag is now missing :-1: 
