### PR TITLE
fix: add openssl11 for rpm signing to EL7 jobs

### DIFF
--- a/images/rpmbuild-centos7/Dockerfile
+++ b/images/rpmbuild-centos7/Dockerfile
@@ -8,11 +8,11 @@ RUN curl -O https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz \
 RUN yum update -y && \
   yum install -y autoconf automake boost boost-filesystem boost-iostreams \
   boost-program-options boost-regex boost-signals boost-system boost-thread \
-  cairo cairo-devel createrepo fontconfig fontconfig-devel \
+  cairo cairo-devel createrepo dnf dnf-plugins-core fontconfig fontconfig-devel \
   freetype freetype-devel gcc gcc-c++ git libdbi libdbi-devel libgfortran \
   libxml2 libxml2-devel m2crypto make ncurses ncurses-devel numpy octave \
-  openssl pango pango-devel perl-devel python3 qtwebkit rpm-build \
-  rpmdevtools rpmlint rpm-sign shadow-utils systemd tar unzip dnf dnf-plugins-core
+  openssl openssl11 pango pango-devel perl-devel python3 qtwebkit rpm-build \
+  rpmdevtools rpmlint rpm-sign shadow-utils systemd tar unzip
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip


### PR DESCRIPTION
Enable for EL7 so we can use rpm signing in GitHub Actions builds