### PR TITLE
fix: correct c7 node version install

### DIFF
--- a/images/rpmbuild-centos7/Dockerfile
+++ b/images/rpmbuild-centos7/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/geonet/base-images/centos:centos7
 # Install prerequisites
-RUN curl -O https://nodejs.org/dist/latest-v20.x/node-v20.11.1-linux-arm64.tar.xz \
+RUN curl -O https://nodejs.org/dist/latest-v20.x/node-v20.11.1-linux-x64.tar.xz \
   && tar --strip-components 1 -xvf node-v* -C /usr/local \
   && yum install -y epel-release
 


### PR DESCRIPTION
mistakenly using arm download for x86_64 target