### PR TITLE
fix: revert to node16 for el7

### DIFF
--- a/images/rpmbuild-centos7/Dockerfile
+++ b/images/rpmbuild-centos7/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/geonet/base-images/centos:centos7
 # Install prerequisites
-RUN curl -O https://nodejs.org/dist/latest-v20.x/node-v20.11.1-linux-x64.tar.xz \
+RUN curl -O https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz \
   && tar --strip-components 1 -xvf node-v* -C /usr/local \
   && yum install -y epel-release
 


### PR DESCRIPTION
Upgrading to node20 for EL7 causing build failures. Revert back to node16 until we get off EL7 entirely

Required for https://github.com/GeoNet/packaging/pull/311