### PR TITLE
chore: remove ubi8

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,10 +14,6 @@ sync:
   #         | xargs -n 1 -l bash -c 'cosign verify -o text --certificate-identity-regexp "$2" --certificate-oidc-issuer-regexp "$1" "$0"'
   - source: docker.io/library/alpine:3.18@sha256:02bb6f428431fbc2809c5d1b41eab5a68350194fb508869a33cb1af4444c9b11
     destination: ghcr.io/geonet/base-images/alpine:3.18 # latest alpine
-  - source: docker.io/redhat/ubi8:8.8@sha256:a7143118671dfc61aca46e8ab9e488500495a3c4c73a69577ca9386564614c13
-    destination: ghcr.io/geonet/base-images/ubi8:8.8
-  - source: docker.io/redhat/ubi8-minimal:8.8@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
-    destination: ghcr.io/geonet/base-images/ubi8-minimal:8.8
   - source: docker.io/datadog/agent:7.47.1@sha256:364b90eb9da1925a4b8a1dca501a9a8e8cd5e8455733a16857284c49d4bf8467
     destination: ghcr.io/geonet/base-images/datadog/agent:7.47.1
   - source: docker.io/datadog/agent:7.47.1@sha256:364b90eb9da1925a4b8a1dca501a9a8e8cd5e8455733a16857284c49d4bf8467


### PR DESCRIPTION
we're not using this image for rhel8 upgrades