### PR TITLE
chore: upgrade to alpine-gdal:1.18

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -122,7 +122,7 @@ build:
   - source: ./images/alpine-xslt/image.yaml
     destination: ghcr.io/geonet/base-images/alpine-xslt:3.18
   - source: ./images/alpine-gdal/image.yaml
-    destination: ghcr.io/geonet/base-images/alpine-gdal:3.15
+    destination: ghcr.io/geonet/base-images/alpine-gdal:3.18
   - source: ./images/texlive/image.yaml
     destination: ghcr.io/geonet/base-images/texlive:latest
   - source: ./images/chart-centos7/Dockerfile

--- a/images/alpine-gdal/image.yaml
+++ b/images/alpine-gdal/image.yaml
@@ -1,11 +1,13 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/v3.15/main
-    - https://dl-cdn.alpinelinux.org/alpine/v3.15/community
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.18/community
   packages:
     - ca-certificates-bundle
     - tzdata
     - gdal
+    - gdal-driver-HDF5
+    - gdal-driver-PNG
 
 archs:
   - x86_64


### PR DESCRIPTION
Previously we downgrade alpine 1.18 to 1.15 for gdal, now in order to use Go 1.21 for services, we're upgrading back to alpine 1.18.
Two extra drivers have been spun off to standalong packages, adding them by apk. 