### PR TITLE
fix: try to run the check suite on upstream sync

### DIFF
--- a/.github/workflows/update-image-digests.yml
+++ b/.github/workflows/update-image-digests.yml
@@ -7,6 +7,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  checks: write
 jobs:
   update-image-digests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this check suite should run when the geonetci bot syncs from quay.io for mutable tags

checks	Work with check runs and check suites. For example, checks: write permits an action to create a check run. For more information, see "Permissions required for GitHub Apps."