### PR TITLE
feat: assign reviewer on creation

### DIFF
--- a/.github/workflows/update-image-digests.yml
+++ b/.github/workflows/update-image-digests.yml
@@ -39,9 +39,9 @@ jobs:
           git branch "${NEW_BRANCH}"
           git checkout "${NEW_BRANCH}"
           git commit -s -m "chore: update sync config.yaml images for ${TIMESTAMP}" -m "updates sync config.yaml images for ${TIMESTAMP}"
-          git push -f origin "${NEW_BRANCH}"
+          git push origin "${NEW_BRANCH}"
 
           if ! gh label list --json name --jq .[].name | grep -Eq '^image-digest-update$'; then
             gh label create image-digest-update || true
           fi
-          gh pr --label image-digest-update create --title "Update sync config.yaml images ${TIMESTAMP}" --body "updates sync config.yaml images for ${TIMESTAMP}"
+          gh pr --label image-digest-update create --title "Update sync config.yaml images ${TIMESTAMP}" --reviewer GeoNet/platform-team --body "updates sync config.yaml images for ${TIMESTAMP}"


### PR DESCRIPTION
will only succeed on first push
created to address issues found in https://github.com/GeoNet/base-images/pull/220