### PR TITLE
feat: add Grafana image

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ list of vendored base images
 | ghcr.io/geonet/base-images/binfmt                               | Cross-platform emulator collection distributed with Docker images              |
 | 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com/datadog-agent | datadog agent for use in ECS                                                   |
 | ghcr.io/geonet/base-images/prometheus                           | Prometheus time series database                                                |
+| ghcr.io/geonet/base-images/grafana/grafana-oss                  | Grafana image for building and displaying dashboards                           |
 
 for tags, check [config.yaml](./config.yaml).
 

--- a/config.yaml
+++ b/config.yaml
@@ -111,6 +111,8 @@ sync:
     auto-update-mutable-tag-digest: true
   - source: quay.io/prometheus/prometheus:v2.53.0@sha256:075b1ba2c4ebb04bc3a6ab86c06ec8d8099f8fda1c96ef6d104d9bb1def1d8bc
     destination: ghcr.io/geonet/base-images/prometheus:v2.53.0
+  - source: docker.io/grafana/grafana-oss:11.1.0@sha256:079600c9517b678c10cda6006b4487d3174512fd4c6cface37df7822756ed7a5
+    destination: ghcr.io/geonet/base-images/grafana/grafana-oss:11.1.0
 build:
   # NOTES
   # - uses dirname of source as context for build


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/16099

Required for volcano dashboard project.

`11.1.0` is the latest version. 
It is based on Alpine.