### PR TITLE
fix: allow sync to finish before failing

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_CI_USER_TOKEN }}
         run: |
-          skopeo sync --all --src yaml --dest docker sync-ghcr.yml ghcr.io/geonet/base-images
+          skopeo sync --all --keep-going --src yaml --dest docker sync-ghcr.yml ghcr.io/geonet/base-images
         if: github.ref_name == 'main'
       - name: copy to ecr
         run: |

--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -51,8 +51,6 @@ cgr.dev:
   images-by-semver:
     chainguard/curl: ">= 8.1.2"
   images:
-    chainguard/node:
-      - '20'
     chainguard/static:
       - 'latest'
     chainguard/nginx:


### PR DESCRIPTION
dry run doesn't catch the missing upstream

run sync even if the upstream is missing on one entry so most things get updates
removing broken chainguard image that is unused ghcr.io/geonet/base-images/node:20