### PR TITLE
feat: change scope of dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,34 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "images/python-arcgis"
     groups:
       python-packages:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "fix"
+      prefix-development: "fix"
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/"
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "fix"
+      prefix-development: "fix"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
currently the dependabot configuration is not useful to us the dependabot system is blocked on merging unhelpful PR's for mkdocs

mkdocs will be addressed in this ticket instead https://github.com/GeoNet/tickets/issues/15171

this change scopes python updates to a component service of a data product (arcgis online uploader base image)

hopefully this means we get automation for image updates from the new image sync tooling