### PR TITLE
fix: add skopeo to vendored software

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -43,6 +43,8 @@ quay.io:
     centos/centos:
       - stream8
       - stream9
+    skopeo/stable:
+      - '1.16'
   images-by-semver:
     prometheus/prometheus: ">= v2.53.0"
     prometheus/snmp-exporter: ">= v0.26.0"


### PR DESCRIPTION
github uses an old version of skopeo and we need an updated one for semver support