### PR TITLE
fix: add alpine node images to ghcr

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -33,6 +33,9 @@ docker.io:
       - v0.9.0
     tonistiigi/binfmt:
       - latest
+    node:
+      - 20.3-alpine3.18
+      - 21.6-alpine3.19
 quay.io:
   tls-verify: true
   images:


### PR DESCRIPTION
20.3-alpine3.18 is what we're currently using across the board. 21.6-alpine3.19 is the new image we want to move to.