### PR TITLE
feat: Go 1.22 base image

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -29,6 +29,7 @@ docker.io:
       - 3.11.4-alpine3.18
     golang:
       - 1.21.12-alpine3.20
+      - 1.22.7-alpine3.20
     koalaman/shellcheck-alpine:
       - v0.9.0
     tonistiigi/binfmt:


### PR DESCRIPTION
A preparation for next update.

Also this fixes a CVE https://pkg.go.dev/vuln/GO-2024-3106