### PR TITLE
fix: change almalinux tags to match dockerhub

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -13,8 +13,8 @@ docker.io:
       - '8.9'
       - '8.10'
       - '8.10-minimal'
-      - '9-base'
-      - '9-minimal'
+      - '9.5'
+      - '9.5-minimal'
     redhat/ubi8:
       - '8.9'
       - '8.10'


### PR DESCRIPTION
the format is different depending if you go for `almalinux/version-number` or `almalinux:version-number`