### PR TITLE
feat: add ringserver image

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -46,6 +46,8 @@ docker.io:
     node:
       - 20.3-alpine3.18
       - 21.6-alpine3.19
+    earthscope/ringsever:
+      - '4.0.0'
 quay.io:
   tls-verify: true
   images:


### PR DESCRIPTION
This updates the synching to include earthscope/ringerver to present a local copy. Only the 4.0.0 image is configured