### PR TITLE
feat: bump ringserver to v4.0.1

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -47,7 +47,7 @@ docker.io:
       - 20.3-alpine3.18
       - 21.6-alpine3.19
     earthscope/ringsever:
-      - '4.0.0'
+      - 'v4.0.1'
 quay.io:
   tls-verify: true
   images:


### PR DESCRIPTION
This origin 4.0.0 should have been v4.0.0, updating at the same time. This is tag on the main github branch, but doesn't seem to have been turned into a release