### PR TITLE
feat: add arm64 support for arbitrary images when they are composite manifests

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -59,6 +59,13 @@ jobs:
         run: |
           podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --retry-times 1 --authfile /run/secrets/skopeo-auth --preserve-digests --keep-going --src yaml --dest docker sync-ghcr.yml ghcr.io/geonet/base-images
         if: github.ref_name == 'main'
+      - name: dry run copy to ghcr.io aarch64
+        run: |
+          podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --all --retry-times 1 --authfile /run/secrets/skopeo-auth --dry-run --preserve-digests --src yaml --dest docker sync-ghcr-all.yml ghcr.io/geonet/base-images
+      - name: copy to ghcr.io
+        run: |
+          podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --all --retry-times 1 --authfile /run/secrets/skopeo-auth --preserve-digests --keep-going --src yaml --dest docker sync-ghcr-all.yml ghcr.io/geonet/base-images
+        if: github.ref_name == 'main'
       - name: copy to ecr
         run: |
           podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --retry-times 1 --authfile /run/secrets/skopeo-auth --preserve-digests --src yaml --dest docker sync-ecr.yml 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com

--- a/sync-ghcr-all.yml
+++ b/sync-ghcr-all.yml
@@ -1,0 +1,5 @@
+docker.io:
+  tls-verify: true
+  images:
+    chainguard/static:
+      - 'latest'

--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -76,8 +76,6 @@ cgr.dev:
   images-by-semver:
     chainguard/curl: ">= 8.1.2"
   images:
-    chainguard/static:
-      - 'latest'
     chainguard/nginx:
       - 'latest'
 


### PR DESCRIPTION
arm images can be published under the same tag as an amd64 image.

in that instance the client OS+arch is assumed to be the desired target.

we need to override this to sync arm64 images to our repository for downstream consumption.