### PR TITLE
fix: add image for go 1.23 with alpine 3.20

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -38,6 +38,7 @@ docker.io:
     golang:
       - 1.21.12-alpine3.20
       - 1.22.7-alpine3.20
+      - 1.23.4-alpine3.20
       - 1.23.4-alpine3.21
     koalaman/shellcheck-alpine:
       - v0.9.0


### PR DESCRIPTION
Some projects are not working with alpine 21 so need this to continue