### PR TITLE
fix: add image for go 1.23 without minor version

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -44,6 +44,7 @@ docker.io:
       - 1.23.5-alpine3.21
       - 1.23.6-alpine3.20
       - 1.23.6-alpine3.21
+      - 1.23-alpine3.31
     koalaman/shellcheck-alpine:
       - v0.9.0
     tonistiigi/binfmt:


### PR DESCRIPTION
Having the minor version pinned is not practical in most cases. When there's a new govuln alert, all CIs fail and require PRs to update the dockerfiles to a new image in over 30 repos.

EDIT.
After talking about it in standup, maybe we should just stick to minor version.... 😭 I don't know what to do.
I didn't know about the scenario last year where the latest version had the vulnerability, but earlier versions didn't.