### PR TITLE
fix: add images for go1.23.5

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -40,6 +40,8 @@ docker.io:
       - 1.22.7-alpine3.20
       - 1.23.4-alpine3.20
       - 1.23.4-alpine3.21
+      - 1.23.5-alpine3.20
+      - 1.23.5-alpine3.21
     koalaman/shellcheck-alpine:
       - v0.9.0
     tonistiigi/binfmt:


### PR DESCRIPTION
Contains patch for https://pkg.go.dev/vuln/GO-2025-3420