### PR TITLE
fix: add images for go1.23.6

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -42,6 +42,8 @@ docker.io:
       - 1.23.4-alpine3.21
       - 1.23.5-alpine3.20
       - 1.23.5-alpine3.21
+      - 1.23.6-alpine3.20
+      - 1.23.6-alpine3.21
     koalaman/shellcheck-alpine:
       - v0.9.0
     tonistiigi/binfmt:


### PR DESCRIPTION
fix: add images for go1.23.6 to fix Vulnerability: [GO-2025-3447](https://pkg.go.dev/vuln/GO-2025-3447)