### PR TITLE
fix: add python3.11-rpm-macros to rpmbuild image

### DIFF
--- a/images/rpmbuild-almalinux8/Dockerfile
+++ b/images/rpmbuild-almalinux8/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf update -y && \
   libxml2-devel make ncurses ncurses-devel nodejs npm octave \
   openssl pango pango-devel perl-devel python3.11 qt5-qtwebengine \
   rpm-build rpmdevtools rpm-sign rpmlint shadow-utils systemd unzip \
-  python3.11-devel python3.11
+  python3.11-devel python3.11 python3.11-rpm-macros
 
 COPY rpmlintrc.toml /etc/xdg/rpmlint/rpmlintrc.toml
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip

--- a/images/rpmbuild-centos-stream9/Dockerfile
+++ b/images/rpmbuild-centos-stream9/Dockerfile
@@ -10,8 +10,9 @@ RUN dnf module enable -y nodejs:20 && \
     fontconfig-devel freetype freetype-devel gcc gcc-c++ git glibc \
     kernel-devel libgfortran libxml2 libxml2-devel make ncurses \
     ncurses-devel nodejs npm python3.11-devel python3.11 \
-    openssl pango pango-devel perl-devel python3.11 qt5-qtbase \
-    rpm-build rpmdevtools rpm-sign rpmlint shadow-utils systemd unzip
+    openssl pango pango-devel perl-devel python3.11 python3.11-rpm-macros \
+    qt5-qtbase rpm-build rpmdevtools rpm-sign rpmlint \
+    shadow-utils systemd unzip
 
 COPY rpmlintrc.toml /etc/xdg/rpmlint/rpmlintrc.toml
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
To avoid the need to install during the build steps in GitHub CI