### PR TITLE
feat: add unity-cli image for dell emc management

### DIFF
--- a/images/dell-emc-cli/Containerfile
+++ b/images/dell-emc-cli/Containerfile
@@ -1,0 +1,8 @@
+FROM docker.io/almalinux:8.9
+
+COPY UnisphereCLI-Linux-64-x86-en_US-5.4.0.2220877-1.x86_64.rpm /tmp
+RUN dnf install -y /tmp/UnisphereCLI-Linux-64-x86-en_US-5.4.0.2220877-1.x86_64.rpm
+RUN rm /tmp/UnisphereCLI-Linux-64-x86-en_US-5.4.0.2220877-1.x86_64.rpm
+RUN dnf clean all
+
+ENTRYPOINT [ "/opt/dellemc/uemcli/bin/uemcli.sh" ]


### PR DESCRIPTION
From previous work updating dell storage certs.

Tracking this Containerfile entry so we don't lose it. If we need to build this image in future we'll need to update the package name.