### PR TITLE
feat: update rpmbuild to almalinux 8.10

### DIFF
--- a/images/rpmbuild-almalinux8/Dockerfile
+++ b/images/rpmbuild-almalinux8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/geonet/base-images/almalinux:8.9
+FROM ghcr.io/geonet/base-images/almalinux:8.10
 # Install prerequisites
 RUN dnf module enable -y nodejs:20 \
   && dnf install -y epel-release 'dnf-command(config-manager)' \


### PR DESCRIPTION
We should drop the Almalinux 8.9 image