### PR TITLE
feat: add almalinux-gsm image for looking at gempa packages

### DIFF
--- a/images/almalinux-gsm/Dockerfile
+++ b/images/almalinux-gsm/Dockerfile
@@ -1,0 +1,41 @@
+FROM ghcr.io/geonet/base-images/almalinux:8.10
+
+LABEL org.opencontainers.image.authors="geonetci@gns.cri.nz"
+
+RUN dnf -y --refresh upgrade && \
+    dnf -y install \
+    expect \
+    python3.11 \
+    python3.11-pip \
+    python3.11-wheel \
+    tree \
+    wget \
+    which
+
+RUN alternatives --set python /usr/bin/python3.11
+
+RUN getent group seiscomp >/dev/null || groupadd -g 3560 seiscomp
+RUN getent passwd seiscomp >/dev/null || useradd -u 3560 -d /home/seiscomp -g seiscomp seiscomp
+
+USER seiscomp
+WORKDIR /home/seiscomp
+ENV PATH="/home/seiscomp/.local/bin:$PATH"
+RUN wget https://data.gempa.de/gsm/gempa-gsm.tar.gz
+RUN tar -xvf gempa-gsm.tar.gz 
+
+RUN python3 -m pip install --user cryptography humanize natsort requests tqdm bs4 gnupg
+
+WORKDIR gsm 
+
+RUN mkdir -p log && \
+    mkdir -p packages
+
+COPY --chown=seiscomp:seiscomp \
+     --chmod=0660 \
+     gsm.exp .
+
+RUN chmod u+x ./gsm.exp
+
+RUN ./gsm.exp
+
+RUN ./gsm update

--- a/images/almalinux-gsm/gsm.exp
+++ b/images/almalinux-gsm/gsm.exp
@@ -1,0 +1,55 @@
+#!/usr/bin/expect
+
+set timeout 4
+
+spawn ./gsm setup
+
+expect -exact "SeisComP release \[6\]:\r"
+
+send -- "6\r"
+
+expect -exact "Operating system \[almalinux\]:\r"
+
+send -- "rhel\r"
+
+expect -exact "Operating system version \[9\]:\r"
+
+send -- "8\r"
+
+expect -exact "System architecture \[x86_64\]:\r"
+
+send -- "x86_64\r"
+
+expect -exact "Do you want to restart the setup for the operating system? \[y\/N\]:\r"
+
+send -- "n\r"
+
+expect -exact "Do you want to use your private repository with gempa modules? Otherwise use the public SeisComP without gempa modules. \[Y\/n\]:\r"
+
+send -- "n\r"
+
+expect -exact "Download dir \[\/home\/seiscomp\/gsm\/packages\]:\r"
+
+send -- "\/home\/seiscomp\/gsm\/packages\r"
+
+expect -exact "Install path \[\/home\/seiscomp\/seiscomp\]:\r"
+
+send -- "\/home\/seiscomp\/seiscomp\r"
+
+expect -exact "Data path \[\/home\/data]:\r"
+
+send -- "\/home\/data\r"
+
+expect -exact "Number of days before the license expires message is displayed \[30\]:\r"
+
+send -- "30\r"
+
+expect -exact "Do you want to check for the downloaded packages using gnupg?: \[y\/N\]:\r"
+
+send -- "n\r"
+
+expect -exact "Do you want to backup for the downloaded packages: \[y\/N\]:\r"
+
+send -- "n\r"
+
+expect eof


### PR DESCRIPTION
Provide an image to make it easy to run gsm to inspect package updates and file layout changes, especially for shared libraries

Defaults to not providing user authentication.

Can be built and run locally:
`podman build --tag almalinux-gsm .`
`podman run --rm -it localhost/almalinux-gsm:latest`
`./gsm info`