### PR TITLE
Drop Almalinux 8.9 and use AlmaLinux 8.10

### DIFF
--- a/images/dell-emc-cli/Containerfile
+++ b/images/dell-emc-cli/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/almalinux:8.9
+FROM ghcr.io/geonet/base-images/almalinux:8.10
 
 COPY UnisphereCLI-Linux-64-x86-en_US-5.4.0.2220877-1.x86_64.rpm /tmp
 RUN dnf install -y /tmp/UnisphereCLI-Linux-64-x86-en_US-5.4.0.2220877-1.x86_64.rpm

--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -10,16 +10,13 @@ docker.io:
       - '3.19'
       - '3.18'
     almalinux:
-      - '8.9'
       - '8.10'
       - '8.10-minimal'
       - '9.5'
       - '9.5-minimal'
     redhat/ubi8:
-      - '8.9'
       - '8.10'
     redhat/ubi8-minimal:
-      - '8.9'
       - '8.10'
     debian:
       - 'bookworm-slim'


### PR DESCRIPTION
Quick clean-up of AlmaLinux use in base-images

The dell-emc image is not intended to be a regular build which is why it's not named `Dockerfile` for the docker build workflow