### PR TITLE
nfc: remove ecr sync for datadog agent

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -66,7 +66,3 @@ jobs:
         run: |
           podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --all --retry-times 1 --authfile /run/secrets/skopeo-auth --preserve-digests --keep-going --src yaml --dest docker sync-ghcr-all.yml ghcr.io/geonet/base-images
         if: github.ref_name == 'main'
-      - name: copy to ecr
-        run: |
-          podman run --secret=skopeo-auth -v "${PWD}:/src" -w /src ghcr.io/geonet/base-images/stable:v1.17 sync --retry-times 1 --authfile /run/secrets/skopeo-auth --preserve-digests --src yaml --dest docker sync-ecr.yml 862640294325.dkr.ecr.ap-southeast-2.amazonaws.com
-        if: github.ref_name == 'main'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ list of vendored base images
 | Image                                                           | Description                                                                    |
 | --------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | ghcr.io/geonet/base-images/alpine                               | standard Alpine base image                                                     |
-| ghcr.io/geonet/base-images/datadog/agent                        | datadog agent                                                                  |
 | ghcr.io/geonet/base-images/debian                               | standard Debian slim image                                                     |
 | ghcr.io/geonet/base-images/git                                  | Alpine with git installed                                                      |
 | ghcr.io/geonet/base-images/git-ssh                              | Alpine with git and ssh installed                                              |

--- a/sync-ecr.yml
+++ b/sync-ecr.yml
@@ -1,4 +1,0 @@
-docker.io:
-  tls-verify: true
-  images-by-semver:
-    datadog/agent: ">=7.51.0"


### PR DESCRIPTION
- not required anymore since `datadog-agent` in ecs are now pointing to official datadog ecr repo
- this also resolves the error on the sync workflow https://github.com/GeoNet/base-images/actions/runs/14375443388