### PR TITLE
feat: add image for python 3.11.9-bullseye

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -28,6 +28,7 @@ docker.io:
       - '1.17.3'
     python:
       - 3.11.4-bullseye
+      - 3.11.9-bullseye
       - 3.12.2-bullseye
       - 3.12.2-alpine3.19
       - 3.11.9-alpine3.19


### PR DESCRIPTION
Going to switch to debian for arcgis-python image