### PR TITLE
feat: add vmagent image

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ list of vendored base images
 | ghcr.io/geonet/base-images/victoria-metrics                     | Victoria metrics time series database and storage engine                       |
 | ghcr.io/geonet/base-images/victoria-logs                        | Victoria logs storage and analysis of log messages                             |
 | ghcr.io/geonet/base-images/vmalert                              | Victoria metrics alerting agent                                                |
+| ghcr.io/geonet/base-images/vmagent                              | Victoria metrics agent for collecting metrics                                  |
 
 for tags, check [config.yaml](./config.yaml).
 

--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -53,6 +53,8 @@ docker.io:
       - 'v1.28.0'
     victoriametrics/vmalert:
       - 'v1.125.1'
+    victoriametrics/vmagent:
+      - 'v1.126.0'
 quay.io:
   tls-verify: true
   images:


### PR DESCRIPTION
This is part of the victoria metrics system, it can be used to monitor the system itself or as an alternative to prometheus