### PR TITLE
feat: update rpmbuild files for almalinux 9 and 10

### DIFF
--- a/images/rpmbuild-almalinux10/Dockerfile
+++ b/images/rpmbuild-almalinux10/Dockerfile
@@ -1,20 +1,60 @@
-FROM ghcr.io/geonet/base-images/almalinux:10.0
+FROM ghcr.io/geonet/base-images/almalinux:10.1
+
 # Install prerequisites
-RUN dnf module enable -y nodejs:20 \
-  && dnf install -y epel-release 'dnf-command(config-manager)' \
-  && dnf config-manager --set-enabled powertools
+RUN dnf install -y epel-release 'dnf-command(config-manager)'
+
 # Update system
 RUN dnf update -y && \
-  dnf install -y boost automake boost-filesystem boost-iostreams \
-  boost-program-options boost-regex boost-signals boost-system \
-  boost-thread cairo cairo-devel dnf-plugins-core fontconfig \
-  fontconfig-devel freetype freetype-devel gcc gcc-c++ git glibc \
-  kernel-devel libdbi libdbi-devel libgfortran libxml2 \
-  libxml2-devel make ncurses ncurses-devel nodejs npm octave \
-  openssl pango pango-devel perl-devel python3.11 qt5-qtwebengine \
-  rpm-build rpmdevtools rpm-sign rpmlint shadow-utils systemd unzip \
-  python3.11-devel python3.11 python3.11-rpm-macros
+    dnf install -y \
+    automake \
+    awscli2 \
+    boost-container \
+    boost-filesystem \
+    boost-iostreams \
+    boost-program-options \
+    boost-regex \
+    boost-system \
+    boost-thread \
+    cairo \
+    cairo-devel \
+    dnf-plugins-core \
+    fontconfig \
+    fontconfig-devel \
+    freetype \
+    freetype-devel \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc \
+    kernel-devel \
+    libdbi \
+    libdbi-devel \
+    libgfortran \
+    libxml2 \
+    libxml2-devel \
+    make \
+    ncurses \
+    ncurses-devel \
+    nodejs \
+    npm \
+    openssl \
+    pango \
+    pango-devel \
+    perl-devel \
+    python3 \
+    python3-devel \
+    python3-numpy \
+    python3-pip \
+    python3-rpm-macros \
+    qt6-qtbase \
+    qt6-qtbase-gui \
+    qt6-qtsvg \
+    rpm-build \
+    rpmdevtools \
+    rpm-sign \
+    rpmlint \
+    shadow-utils \
+    systemd \
+    unzip
 
 COPY rpmlintrc.toml /etc/xdg/rpmlint/rpmlintrc.toml
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip
-RUN ./aws/install

--- a/images/rpmbuild-almalinux9/Dockerfile
+++ b/images/rpmbuild-almalinux9/Dockerfile
@@ -1,20 +1,68 @@
-FROM ghcr.io/geonet/base-images/almalinux:9.6
+FROM ghcr.io/geonet/base-images/almalinux:9.7
+
 # Install prerequisites
-RUN dnf module enable -y nodejs:20 \
-  && dnf install -y epel-release 'dnf-command(config-manager)' \
-  && dnf config-manager --set-enabled powertools
+RUN dnf module enable -y nodejs:20 && \
+  dnf install -y epel-release 'dnf-command(config-manager)' && \
+  dnf config-manager --set-enabled crb
+  
 # Update system
-RUN dnf update -y && \
-  dnf install -y boost automake boost-filesystem boost-iostreams \
-  boost-program-options boost-regex boost-signals boost-system \
-  boost-thread cairo cairo-devel dnf-plugins-core fontconfig \
-  fontconfig-devel freetype freetype-devel gcc gcc-c++ git glibc \
-  kernel-devel libdbi libdbi-devel libgfortran libxml2 \
-  libxml2-devel make ncurses ncurses-devel nodejs npm octave \
-  openssl pango pango-devel perl-devel python3.11 qt5-qtwebengine \
-  rpm-build rpmdevtools rpm-sign rpmlint shadow-utils systemd unzip \
-  python3.11-devel python3.11 python3.11-rpm-macros
+RUN dnf update -y \
+  && dnf install -y \
+    automake \
+    boost \
+    boost-filesystem \
+    boost-iostreams \
+    boost-program-options \
+    boost-regex \
+    boost-signals \
+    boost-system \
+    boost-thread \
+    cairo \
+    cairo-devel \
+    dnf-plugins-core \
+    fontconfig \
+    fontconfig-devel \
+    freetype \
+    freetype-devel \
+    gcc \
+    gcc-c++ \
+    git \
+    glibc \
+    kernel-devel \
+    libdbi \
+    libdbi-devel \
+    libgfortran \
+    libxml2 \
+    libxml2-devel \
+    make \
+    ncurses \
+    ncurses-devel \
+    nodejs \
+    npm \
+    octave \
+    openssl \
+    pango \
+    pango-devel \
+    perl-devel \
+    python3.11 \
+    python3.11-devel \
+    python3.11-numpy \
+    python3.11-pip \
+    python3.11-rpm-macros \
+    qt5-qtbase \
+    qt5-qtbase-gui \
+    qt5-qtsvg \
+    rpm-build \
+    rpmdevtools \
+    rpm-sign \
+    rpmlint \
+    shadow-utils \
+    systemd \
+    unzip
 
 COPY rpmlintrc.toml /etc/xdg/rpmlint/rpmlintrc.toml
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip
+  
 RUN ./aws/install


### PR DESCRIPTION
These are updates from AlmaLinux 8 file.

AlmaLinux has moved away from the old 'powertools'/'crl' modular layout the same as Red Hat. The packages show now be easier to install.

EL10 also includes the `awscli2` package so we don't need to maintain a manual install of the zip file.

File conflicts with main branch should be resolved now.