### PR TITLE
fix: adjust docker ringserver tag

### DIFF
--- a/sync-ghcr.yml
+++ b/sync-ghcr.yml
@@ -60,7 +60,7 @@ docker.io:
       - 24.9-alpine3.21
     earthscope/ringserver:
       - 'v4.0.1'
-      - 'v4.5.1'
+      - '4.5.1'
     victoriametrics/victoria-metrics:
       - 'v1.117.1'
       - 'latest'


### PR DESCRIPTION
It appears the tagging schema used by earthscope has changed to drop the leading v for docker.io.

Evident in https://hub.docker.com/r/earthscope/ringserver/tags?ordering=-last_updated