### PR TITLE
fix: update github actions deps for aws-actions in magpi build

### DIFF
--- a/.github/workflows/build-magpi.yml
+++ b/.github/workflows/build-magpi.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: ap-southeast-2
           role-to-assume: arn:aws:iam::615890063537:role/tf-dev-github-actions-geonet-codebuild-magpi
           role-duration-seconds: 3600
           role-session-name: "github-actions-base-images-arm64-magpi"
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.19
         env:
           GHCR_USER: ${{ github.actor }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update versions of aws-actions for configure-aws-credentials and aws-codebuild-run-build